### PR TITLE
Removing a dead link of the community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ Where to find other plotter and drawbot friends.
 - [PlotterArt Subreddit](https://www.reddit.com/r/PlotterArt)
 - [AxiDraw Subreddit](https://www.reddit.com/r/axidraw)
 - [Generative Art Subreddit](https://www.reddit.com/r/generative)
-- [Chiplotle-discuss](https://lists.columbia.edu/mailman/listinfo/chiplotle-discuss) - Fairly inactive mailing list for the Chiplotle HPGL Python library with some general plotter talk.
 - [Plotter People](https://plotterpeople.github.io/) - In-person meetups (SF and NYC so far) with talks and plotter art galleries.
 
 ## Plotter Art For Sale


### PR DESCRIPTION
Hey @beardicus,

just removing a dead link from the community section.

Cheers,
Peter