### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ A curated list of code and resources for computer-controlled drawing machines an
 HPGL is a serial/text-based protocol used by most old pen plotters, and even many new vinyl cutters.
 
 - [Chiplotle](https://github.com/drepetto/chiplotle) - Python library for generating HPGL and interfacing with serial plotters.
+- [Chiplotle on Parallel Port](https://gitlab.com/mononym/chiplotle-on-parallel-port) - Tweak of Chiplotle to work with a parallel port connection.
 - [HPGL Reference Guide](https://www.isoplotec.co.jp/HPGL/eHPGL.htm) - HTML-based HPGL Reference.
 - [HP 7475A Interfacing and Programming Manual](https://archive.org/details/HP7475AInterfacingandProgrammingManual) - Scanned PDF manual that contains a full HPGL reference.
 - [djipco/hpgl](https://github.com/djipco/hpgl) - A Node.js library to communicate with HPGL-compatible plotters and printers.


### PR DESCRIPTION
Add entry for HPGL references: a Chiplotle tweak to extend its usage to parallel port connected plotters.