### PR TITLE
Remove link to disabled site

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ Where to find other plotter and drawbot friends.
 - [BustBright](https://mkt.com/bustbright)
 - [Martin O'Leary](https://shop.mewo2.com)
 - [Geoffrey Bradway](https://www.chromatocosmos.com/)
-- [Yuin Chien](http://store.yuinchien.com/)
 - [Andrew Heumann](https://shop.andrewheumann.com/)
 - [brubsby](http://shop.brubsby.com/)
 - [Arjan van der Meij](https://dutchplottr.nl/en/)


### PR DESCRIPTION
This online store appears to no longer be available: "Website Expired"