### PR TITLE
Add MCHN.ART to Plotter Art For Sale

### DIFF
--- a/.worklogs/2026-02-24-222813-awesome-plotters-pr.md
+++ b/.worklogs/2026-02-24-222813-awesome-plotters-pr.md
@@ -1,0 +1,25 @@
+# Add MCHN.ART to awesome-plotters Plotter Art For Sale
+
+**Date:** 2026-02-24 22:28
+**Scope:** README.md
+
+## Summary
+Added MCHN.ART to the "Plotter Art For Sale" section of the awesome-plotters list, in alphabetical order between Michael Fogleman and Michelle Chandra.
+
+## Context & Problem
+User wanted to submit a PR to beardicus/awesome-plotters adding MCHN.ART (machine-executed original artwork, pen plotter art from Lisbon, Portugal) to the curated list.
+
+## Decisions Made
+
+### Alphabetical placement
+- **Chose:** Insert between Michael Fogleman and Michelle Chandra
+- **Why:** "MCHN" sorts after "Mich" (Michael) but before "Mich" (Michelle) — MCH < MIC alphabetically
+
+## Information Sources
+- User-provided instructions with exact line content and PR metadata
+- Existing README.md structure and formatting conventions
+
+## Next Steps / Continuation Plan
+1. Commit the change
+2. Push to fork
+3. Create PR with specified title and body

--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ Artists selling plotter art online.
 - [inconvergent](http://buy.inconvergent.net)
 - [Ingrid Burrington](https://wares.lifewinning.com)
 - [Michael Fogleman](https://www.michaelfogleman.com/plotter)
+- [MCHN.ART](https://mchn.art)
 - [Michelle Chandra](https://www.dirtalleydesign.com/)
 - [Paul Rickards](https://shop.paulrickards.com)
 - [Pedro Alcocer](https://store.pedroalcocer.com/)


### PR DESCRIPTION
Adding MCHN.ART — machine-executed original artwork (1-of-1 physical pieces) created with pen plotters and algorithmic systems. Acrylic ink on cotton canvas. Based in Lisbon, Portugal.

https://mchn.art